### PR TITLE
media-rootの宣言

### DIFF
--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -120,3 +120,4 @@ USE_TZ = True
 
 STATIC_URL = '/static/'
 STATIC_ROOT = os.path.join(BASE_DIR, 'static')
+MEDIA_ROOT = Path(BASE_DIR / 'media')


### PR DESCRIPTION
### 概要
media-rootの宣言をする

### 背景
pythonanywhereにてデプロイする際、media-rootが宣言されていないとNameErrorが出てきたため

### 確認事項

- [ ] 正しくデプロイができる